### PR TITLE
fix: clear passwordConfirm after create user in db

### DIFF
--- a/script/seed.js
+++ b/script/seed.js
@@ -22,6 +22,13 @@ async function seed() {
       return User.create(data);
     })
   );
+
+  //clear passwordConfirm field in db
+  users.forEach(async (user) => {
+    user.passwordConfirm = '';
+    await user.save({ validate: false });
+  });
+
   // Creating Products
   const product = await Promise.all(
     productData.map((data) => {

--- a/server/auth/authController.js
+++ b/server/auth/authController.js
@@ -31,6 +31,11 @@ const signup = asyncHandler(async (req, res, next) => {
     password,
     passwordConfirm,
   });
+
+  // clear passwordConfirm field in db
+  newUser.passwordConfirm = '';
+  await newUser.save({ validate: false });
+
   // 2. create token
   const token = newUser.generateToken();
 


### PR DESCRIPTION
fix bug: clear passwordConfirm in database. 

The old way, after creating a user instance, I only hash the password, the passwordConfirm at the user table is still in plain text. 
That why I fix this bug. 